### PR TITLE
use net.IP instead of calculating ipValue

### DIFF
--- a/etc/multi.yaml
+++ b/etc/multi.yaml
@@ -29,7 +29,7 @@ nodes :
     master : 127.0.0.1:3306
 
     # slave represents a real mysql salve server,and the number after '@' is 
-	#read load weight of this slave.
+    # read load weight of this slave.
     slave : 192.168.0.11:3307@2,192.168.0.12:3307@5
     #down_after_noalive : 300
 - 


### PR DESCRIPTION
Use the type net.IP to parse ip string.

Also, use spaces instead of tabs which will lead to:

> parse config file error:yaml:  line 31:  found character that cannot start any token