### PR TITLE
fix call mysql_list_fields error in php code;

### DIFF
--- a/proxy/server/conn_select.go
+++ b/proxy/server/conn_select.go
@@ -95,7 +95,7 @@ func (c *ClientConn) handleFieldList(data []byte) error {
 	}
 	defer co.Close()
 
-	if err = co.UseDB(c.schema.db); err != nil {
+	if err = co.UseDB(c.db); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Gavin Tao <gavin.tao17@gmail.com>

php test code
```
<?php
$link = mysql_connect('127.0.0.1:9696', 'kingshard', 'kingshard');

$db_selected = mysql_select_db("mysql", $link);

$fields = mysql_list_fields("mysql", "user", $link);
$columns = mysql_num_fields($fields);

for ($i = 0; $i < $columns; $i++) {
    echo mysql_field_name($fields, $i) . " ";
}
?>
```