### PR TITLE
improve[buildFuncExprValues function]

### DIFF
--- a/proxy/server/conn_select.go
+++ b/proxy/server/conn_select.go
@@ -360,6 +360,17 @@ func (c *ClientConn) buildFuncExprValues(
 	var rowEmpty bool
 
 	values := make([][]interface{}, 0, len(rs))
+
+	if len(funcExprs) == len(rs[0].Values[0]) {
+		value := make([]interface{}, len(rs[0].Fields))
+		for k := range funcExprs {
+			value[k] = funcExprValues[k]
+		}
+		values = append(values, value)
+
+		return values, nil
+	}
+
 	for i := 0; i < len(rs); i++ {
 		*status |= rs[i].Status
 		//iterate every row in the resultset(rs[i])
@@ -384,15 +395,6 @@ func (c *ClientConn) buildFuncExprValues(
 			}
 			values = append(values, rs[i].Values[j])
 		}
-	}
-
-	//generate one row just for sum or count
-	if len(values) == 0 {
-		value := make([]interface{}, len(rs[0].Fields))
-		for k := range funcExprs {
-			value[k] = funcExprValues[k]
-		}
-		values = append(values, value)
 	}
 
 	return values, nil


### PR DESCRIPTION
Signed-off-by: Gavin Tao <gavin.tao17@gmail.com>


我认为可以优化buildFuncExprValues这个方法。
先判断funcExprs是不是等于select的字段数，如果相等，直接创建结果集，返回。若不相等才进行结果集的遍历处理。
我想这样可以省掉大部分的循环循环时间，不知flike怎么看？

而且类似这样的sql语句，会更加有效率
select count(*), sum(a), sum(b), sum(c) from t;