### PR TITLE
always be tcp

### DIFF
--- a/proxy/server/server.go
+++ b/proxy/server/server.go
@@ -163,9 +163,9 @@ func NewServer(cfg *config.Config) (*Server, error) {
 
 	var err error
 	netProto := "tcp"
-	if strings.Contains(netProto, "/") {
-		netProto = "unix"
-	}
+//	if strings.Contains(netProto, "/") {
+//		netProto = "unix"
+//	}
 	s.listener, err = net.Listen(netProto, s.addr)
 
 	if err != nil {


### PR DESCRIPTION
netProto := "tcp"
netProto中没有"/"。