### PR TITLE
add new shard type - separator range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,8 @@ type ShardConfig struct {
 	Locations     []int    `yaml:"locations"`
 	Type          string   `yaml:"type"`
 	TableRowLimit int      `yaml:"table_row_limit"`
+	Seps		  []string `yaml:"seps"`
+	KeyType		  string   `yaml:"key_type"`
 }
 
 func ParseConfigData(data []byte) (*Config, error) {

--- a/etc/ks.yaml
+++ b/etc/ks.yaml
@@ -77,3 +77,17 @@ schema :
         nodes: [node1, node2]
         locations: [4,4]
         table_row_limit: 10000
+
+    -
+        #create table test_shard_sep_range(
+        #   recdate date not null,
+        #   userid int not null,
+        #   primary key(recdate, userid)
+        #)engine=innodb default charset=utf8
+        table: test_shard_sep_range
+        key: recdate
+        nodes: [node1, node2]
+        locations: [2, 2]
+        seps: [2015-09-01, 2015-10-01, 2015-11-01]
+        #key type string or int
+        key_type: string

--- a/proxy/router/sep_shard.go
+++ b/proxy/router/sep_shard.go
@@ -1,0 +1,65 @@
+package router
+
+import (
+	"strconv"
+	"strings"
+)
+
+func StrValue(value interface{}) string {
+	switch val := value.(type) {
+	case int:
+		return strconv.Itoa(val)
+	case int64:
+		return strconv.FormatInt(val, 10)
+	case uint64:
+		return strconv.FormatUint(val, 10)
+	case string:
+		return val
+	case []byte:
+		return string(val[:])
+	}
+	panic(NewKeyError("Unexpected key variable type %T", value))
+}
+
+type StrSepRangeShard struct {
+	Seps []string
+}
+
+func (s *StrSepRangeShard) FindForKey(key interface{}) (int, error) {
+	v := StrValue(key)
+	for i, sep := range s.Seps  {
+		switch strings.Compare(v, sep) {
+		case 0:
+			return i + 1, nil
+		case -1:
+			return i, nil
+		}
+	}
+	return len(s.Seps), nil
+}
+
+type IntSepRangeShard struct {
+	Seps []int64
+}
+
+func (s *IntSepRangeShard) FindForKey(key interface{}) (int, error) {
+	v := NumValue(key)
+	for i, sep := range s.Seps  {
+		if (sep == v) {
+			return i + 1, nil
+		} else if (sep > v) {
+			return i, nil
+		}
+	}
+	return len(s.Seps), nil
+}
+
+func ParseIntSepSharding(Seps []string) ([]int64, error) {
+	length := len(Seps)
+	ranges := make([]int64, length)
+
+	for i := 0; i < length; i++ {
+		ranges[i] = NumValue(Seps[i])
+	}
+	return ranges, nil
+}


### PR DESCRIPTION
"range"类型使用"table_row_limit"太不灵活了，主键必须是整形。
增加"sep_range"，使用配置项"seps"来划分每个table负责的数据，
同时增加了"key_type"来指明"key"是string还是int，从而采用不同的比较方式。

之前没有写过go，所以写的不好的地方，作者可以斧正，谢谢！