### PR TITLE
add new shard type - separator range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,8 @@ type ShardConfig struct {
 	Locations     []int    `yaml:"locations"`
 	Type          string   `yaml:"type"`
 	TableRowLimit int      `yaml:"table_row_limit"`
+	Seps		  []string `yaml:"seps"`
+	KeyType		  string   `yaml:"key_type"`
 }
 
 func ParseConfigData(data []byte) (*Config, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -64,8 +64,8 @@ type ShardConfig struct {
 	Locations     []int    `yaml:"locations"`
 	Type          string   `yaml:"type"`
 	TableRowLimit int      `yaml:"table_row_limit"`
-	Seps		  []string `yaml:"seps"`
-	KeyType		  string   `yaml:"key_type"`
+	Seps          []string `yaml:"seps"`
+	KeyType       string   `yaml:"key_type"`
 }
 
 func ParseConfigData(data []byte) (*Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -162,7 +162,7 @@ schema :
 		DB:        "kingshard",
 		Nodes:     []string{"node1", "node2", "node3"},
 		Default:   "node1",
-		ShardRule: []ShardConfig{testShard_1, testShard_2},
+		ShardRule: []ShardConfig{testShard_1, testShard_2, testShard_3},
 	}
 
 	if !reflect.DeepEqual(cfg.Schema, testSchema) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -68,6 +68,14 @@ schema :
       nodes: [node2, node3]
       locations: [4,4]
       table_row_limit: 10000
+    -
+      table: test_shard_sep_range
+      key: recdate
+      type: sep_range
+      nodes: [node1, node3]
+      locations: [2,2]
+      seps: [2015-09-01, 2015-10-01, 2015-11-01]
+      key_type: string
 `)
 
 	cfg, err := ParseConfigData(testConfigData)
@@ -132,7 +140,21 @@ schema :
 		t.Fatal("ShardConfig1 must equal")
 	}
 
-	if 2 != len(cfg.Schema.ShardRule) {
+	testShard_3 := ShardConfig{
+		Table:     "test_shard_sep_range",
+		Key:       "recdate",
+		Nodes:     []string{"node1", "node3"},
+		Type:      "sep_range",
+		Locations: []int{2, 2},
+		Seps:      []string{"2015-09-01", "2015-10-01", "2015-11-01"},
+		KeyType:   "string",
+	}
+	if !reflect.DeepEqual(cfg.Schema.ShardRule[2], testShard_3) {
+		fmt.Printf("%v\n", cfg.Schema.ShardRule[2])
+		t.Fatal("ShardConfig2 must equal")
+	}
+
+	if 3 != len(cfg.Schema.ShardRule) {
 		t.Fatal("ShardRule must 2")
 	}
 

--- a/etc/ks.yaml
+++ b/etc/ks.yaml
@@ -77,3 +77,17 @@ schema :
         nodes: [node1, node2]
         locations: [4,4]
         table_row_limit: 10000
+
+    -
+        #create table test_shard_sep_range(
+        #   recdate date not null,
+        #   userid int not null,
+        #   primary key(recdate, userid)
+        #)engine=innodb default charset=utf8
+        table: test_shard_sep_range
+        key: recdate
+        nodes: [node1, node2]
+        locations: [2, 2]
+        seps: [2015-09-01, 2015-10-01, 2015-11-01]
+        #key type string or int
+        key_type: string

--- a/proxy/router/planbuilder.go
+++ b/proxy/router/planbuilder.go
@@ -108,7 +108,7 @@ func (plan *Plan) getTableIndexs(expr sqlparser.BoolExpr) ([]int, error) {
 		case "in":
 			return plan.getTableIndexsByTuple(criteria.Right)
 		case "not in":
-			if plan.Rule.Type == RangeRuleType {
+			if plan.Rule.Type == RangeRuleType || plan.Rule.Type == SepRangeRuleType {
 				return plan.TableIndexs, nil
 			}
 

--- a/proxy/router/router.go
+++ b/proxy/router/router.go
@@ -25,15 +25,15 @@ import (
 )
 
 var (
-	DefaultRuleType 	= "default"
-	HashRuleType    	= "hash"
-	RangeRuleType   	= "range"
-	SepRangeRuleType 	= "sep_range"
+	DefaultRuleType  = "default"
+	HashRuleType     = "hash"
+	RangeRuleType    = "range"
+	SepRangeRuleType = "sep_range"
 )
 
 var (
-	StrKeyType	= "string"
-	IntKeyType	= "int"
+	StrKeyType = "string"
+	IntKeyType = "int"
 )
 
 type Rule struct {
@@ -197,7 +197,7 @@ func parseShard(r *Rule, cfg *config.ShardConfig) error {
 		r.Shard = &NumRangeShard{Shards: rs}
 	} else if r.Type == SepRangeRuleType {
 		seps := cfg.Seps
-		if len(seps) + 1 != len(r.TableToNode) {
+		if len(seps)+1 != len(r.TableToNode) {
 			return fmt.Errorf("seps %d not equal tables %d", len(seps), len(r.TableToNode))
 		}
 

--- a/proxy/router/sep_shard.go
+++ b/proxy/router/sep_shard.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"strconv"
-	"strings"
 )
 
 func StrValue(value interface{}) string {
@@ -27,15 +26,28 @@ type StrSepRangeShard struct {
 
 func (s *StrSepRangeShard) FindForKey(key interface{}) (int, error) {
 	v := StrValue(key)
-	for i, sep := range s.Seps  {
-		switch strings.Compare(v, sep) {
-		case 0:
+	for i, sep := range s.Seps {
+		switch {
+		case v == sep:
 			return i + 1, nil
-		case -1:
+		case v < sep:
 			return i, nil
 		}
 	}
 	return len(s.Seps), nil
+}
+
+func (s *StrSepRangeShard) EqualStart(key interface{}, index int) bool {
+	if index == 0 {
+		return false
+	}
+
+	v := StrValue(key)
+	return s.Seps[index-1] == v
+}
+
+func (s *StrSepRangeShard) EqualStop(key interface{}, index int) bool {
+	return false
 }
 
 type IntSepRangeShard struct {
@@ -44,14 +56,32 @@ type IntSepRangeShard struct {
 
 func (s *IntSepRangeShard) FindForKey(key interface{}) (int, error) {
 	v := NumValue(key)
-	for i, sep := range s.Seps  {
-		if (sep == v) {
+	for i, sep := range s.Seps {
+		if sep == v {
 			return i + 1, nil
-		} else if (sep > v) {
+		} else if sep > v {
 			return i, nil
 		}
 	}
 	return len(s.Seps), nil
+}
+
+func (s *IntSepRangeShard) EqualStart(key interface{}, index int) bool {
+	if index == 0 {
+		return false
+	}
+
+	v := NumValue(key)
+	return s.Seps[index-1] == v
+}
+
+func (s *IntSepRangeShard) EqualStop(key interface{}, index int) bool {
+	if index == len(s.Seps) {
+		return false
+	}
+
+	v := NumValue(key)
+	return s.Seps[index+1]-1 == v
 }
 
 func ParseIntSepSharding(Seps []string) ([]int64, error) {

--- a/proxy/router/sep_shard.go
+++ b/proxy/router/sep_shard.go
@@ -1,0 +1,65 @@
+package router
+
+import (
+	"strconv"
+	"strings"
+)
+
+func StrValue(value interface{}) string {
+	switch val := value.(type) {
+	case int:
+		return strconv.Itoa(val)
+	case int64:
+		return strconv.FormatInt(val, 10)
+	case uint64:
+		return strconv.FormatUint(val, 10)
+	case string:
+		return val
+	case []byte:
+		return string(val[:])
+	}
+	panic(NewKeyError("Unexpected key variable type %T", value))
+}
+
+type StrSepRangeShard struct {
+	Seps []string
+}
+
+func (s *StrSepRangeShard) FindForKey(key interface{}) (int, error) {
+	v := StrValue(key)
+	for i, sep := range s.Seps  {
+		switch strings.Compare(v, sep) {
+		case 0:
+			return i + 1, nil
+		case -1:
+			return i, nil
+		}
+	}
+	return len(s.Seps), nil
+}
+
+type IntSepRangeShard struct {
+	Seps []int64
+}
+
+func (s *IntSepRangeShard) FindForKey(key interface{}) (int, error) {
+	v := NumValue(key)
+	for i, sep := range s.Seps  {
+		if (sep == v) {
+			return i + 1, nil
+		} else if (sep > v) {
+			return i, nil
+		}
+	}
+	return len(s.Seps), nil
+}
+
+func ParseIntSepSharding(Seps []string) ([]int64, error) {
+	length := len(Seps)
+	ranges := make([]int64, length)
+
+	for i := 0; i < length; i++ {
+		ranges[i] = NumValue(Seps[i])
+	}
+	return ranges, nil
+}


### PR DESCRIPTION
"range"类型使用"table_row_limit"太不灵活了，主键必须是整形。
增加"sep_range"，使用配置项"seps"来划分每个table负责的数据，
同时增加了"key_type"来指明"key"是string还是int，从而采用不同的比较方式。


进行了go fmt处理；
同时增加unit test；