### PR TITLE
fix typo in doc/KingDoc/kingshard_quick_try.md

### DIFF
--- a/doc/KingDoc/kingshard_quick_try.md
+++ b/doc/KingDoc/kingshard_quick_try.md
@@ -135,25 +135,23 @@
 
     # schema defines which db can be used by client and this db's sql will be executed in which nodes
     schema :
-    -
         db : kingshard
         nodes: [node1,node2]
 		default: node1
-            shard:
-            -   
-                table: test_shard_hash
-                key: id
-                nodes: [node1, node2]
-                type: hash
-                locations: [4,4]
-
-            -   
-                table: test_shard_range
-                key: id
-                type: range
-                nodes: [node1, node2]
-                locations: [4,4]
-                table_row_limit: 10000
+        shard:
+        -   
+            table: test_shard_hash
+            key: id
+            nodes: [node1, node2]
+            type: hash
+            locations: [4,4]
+        -   
+            table: test_shard_range
+            key: id
+            type: range
+            nodes: [node1, node2]
+            locations: [4,4]
+            table_row_limit: 10000
 
 ```
 
@@ -184,8 +182,8 @@
 
 创建test_shard_hash分表(_0000~_0007), _0001~_0003在node1(mysqld2)上创建, _0004~_0007在node2(mysqld3)上创建。
 
-    for i in `seq 0 3`;do /usr/bin/mysql -h 127.0.0.1 -P 3307 -u root -proot kingshard -e "CREATE TABLE IF NOT EXISTS test_shard_hash_000"${i}" ( id BIGINT(64) UNSIGNED  NOT NULL, str VARCHAR(256), f DOUBLE, e enum('test1', 'test2'), u tinyint unsigned, i tinyint, ni tinyint, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;";done
-    for i in `seq 4 7`;do /usr/bin/mysql -h 127.0.0.1 -P 3308 -u root -proot kingshard -e "CREATE TABLE IF NOT EXISTS test_shard_hash_000"${i}" ( id BIGINT(64) UNSIGNED  NOT NULL, str VARCHAR(256), f DOUBLE, e enum('test1', 'test2'), u tinyint unsigned, i tinyint, ni tinyint, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;";done
+    for i in `seq 0 3`;do /usr/bin/mysql -h 127.0.0.1 -P 3307 -u root -proot kingshard -e "CREATE TABLE IF NOT EXISTS test_shard_hash_000"${i}" ( id BIGINT(64) UNSIGNED  NOT NULL, str VARCHAR(256), f DOUBLE, e enum('test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7', 'test8', 'test9', 'test10'), u tinyint unsigned, i tinyint, ni tinyint, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;";done
+    for i in `seq 4 7`;do /usr/bin/mysql -h 127.0.0.1 -P 3308 -u root -proot kingshard -e "CREATE TABLE IF NOT EXISTS test_shard_hash_000"${i}" ( id BIGINT(64) UNSIGNED  NOT NULL, str VARCHAR(256), f DOUBLE, e enum('test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7', 'test8', 'test9', 'test10'), u tinyint unsigned, i tinyint, ni tinyint, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;";done
 
 ###插入数据
 


### PR DESCRIPTION
顺便请教一个问题：
在 `kingshard_quick_try.md` 末尾的说明：
```
注意kingshard不支持 select * from test_hard_hash查询, 只支持带条件的查询。
```
但实际尝试去执行 `select * from test_hard_hash` 是可以拿到所插入的 10 条记录，这里的不支持是什么含义的？