### PR TITLE
fix #183, 对于in的分表查询，重新构建in子句，将不同value分配到不同的table index

### DIFF
--- a/proxy/router/planbuilder.go
+++ b/proxy/router/planbuilder.go
@@ -39,6 +39,8 @@ type Plan struct {
 	//the rows for insert or replace.
 	Rows map[int]sqlparser.Values
 
+	SubTableValueGroups map[int]sqlparser.ValTuple  //按照tableIndex存放ValueExpr
+	InRightToReplace *sqlparser.ComparisonExpr      //记录in的右边Expr,用来动态替换不同table in的值
 	RouteTableIndexs []int
 	RouteNodeIndexs  []int
 	RewrittenSqls    map[string][]string
@@ -386,6 +388,7 @@ func (plan *Plan) getTableIndexByBoolExpr(node sqlparser.BoolExpr) ([]int, error
 			left := plan.getValueType(node.Left)
 			right := plan.getValueType(node.Right)
 			if left == EID_NODE && right == LIST_NODE {
+				plan.InRightToReplace=node
 				return plan.getTableIndexs(node)
 			}
 		}
@@ -402,17 +405,26 @@ func (plan *Plan) getTableIndexByBoolExpr(node sqlparser.BoolExpr) ([]int, error
 
 //获得(12,14,23)对应的table index
 func (plan *Plan) getTableIndexsByTuple(valExpr sqlparser.ValExpr) ([]int, error) {
-	shardset := make(map[int]bool)
+	shardset := make(map[int]sqlparser.ValTuple)
 	switch node := valExpr.(type) {
 	case sqlparser.ValTuple:
 		for _, n := range node {
+			//n.Format()
 			index, err := plan.getTableIndexByValue(n)
+
 			if err != nil {
 				return nil, err
 			}
-			shardset[index] = true
+			valExprs := shardset[index]
+
+			if(valExprs==nil){
+				valExprs = make([]sqlparser.ValExpr, 0)
+			}
+			valExprs=append(valExprs,n)
+			shardset[index] = valExprs
 		}
 	}
+	plan.SubTableValueGroups = shardset
 	shardlist := make([]int, len(shardset))
 	index := 0
 	for k := range shardset {

--- a/proxy/router/router.go
+++ b/proxy/router/router.go
@@ -591,6 +591,14 @@ func (r *Router) rewriteSelectSql(plan *Plan, node *sqlparser.Select, tableIndex
 		//do not change limit
 		newLimit = node.Limit
 	}
+
+	if(plan.InRightToReplace!=nil){
+		//assign corresponding values to different table index
+		plan.InRightToReplace.Right=plan.SubTableValueGroups[tableIndex]
+
+	}
+
+
 	buf.Fprintf("%v%v%v%v%v%s",
 		node.Where,
 		node.GroupBy,

--- a/proxy/router/router_test.go
+++ b/proxy/router/router_test.go
@@ -342,6 +342,15 @@ func checkPlan(t *testing.T, sql string, tableIndexs []int, nodeIndexs []int) {
 	t.Logf("rewritten_sql=%v", plan.RewrittenSqls)
 
 }
+func TestWhereInPartitionByTableIndex(t *testing.T){
+	var sql string
+	//2016-03-06 13:37:26
+	sql = "select * from test1 where id in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22) "
+	checkPlan(t, sql,
+		[]int{0,1,2,3,4,5,6,7,8,9,10,11},
+		[]int{0,1,2},
+	)
+}
 
 func TestDatePlan(t *testing.T) {
 	var sql string


### PR DESCRIPTION
参考test case router_test.TestWhereInPartitionByTableIndex