### PR TITLE
当分表key值是数字字符串时优先转换为整数(int)类型进行hash计算。

### DIFF
--- a/proxy/router/shard.go
+++ b/proxy/router/shard.go
@@ -81,7 +81,11 @@ func HashValue(value interface{}) uint64 {
 	case int64:
 		return uint64(val)
 	case string:
-		return uint64(crc32.ChecksumIEEE(hack.Slice(val)))
+		if v, err := strconv.ParseInt(val, 10, 64); err != nil {
+			return uint64(crc32.ChecksumIEEE(hack.Slice(val)))
+		} else {
+			return uint64(v)
+		}
 	case []byte:
 		return uint64(crc32.ChecksumIEEE(val))
 	}


### PR DESCRIPTION
以便解决分表时，如：where id=1 与 where id="1" 这种情况下的id hash值保持一样；