### PR TITLE
FIX error parsing of not in express

### DIFF
--- a/proxy/router/planbuilder.go
+++ b/proxy/router/planbuilder.go
@@ -93,16 +93,10 @@ func (plan *Plan) getHashShardTableIndex(expr sqlparser.BoolExpr) ([]int, error)
 				return nil, err
 			}
 			return []int{index}, nil
-		case "<", "<=", ">", ">=":
+		case "<", "<=", ">", ">=", "not in":
 			return plan.Rule.SubTableIndexs, nil
 		case "in":
 			return plan.getTableIndexsByTuple(criteria.Right)
-		case "not in":
-			l, err := plan.getTableIndexsByTuple(criteria.Right)
-			if err != nil {
-				return nil, err
-			}
-			return plan.notList(l), nil
 		}
 	case *sqlparser.RangeCond: //between ... and ...
 		return plan.Rule.SubTableIndexs, nil

--- a/proxy/router/router_test.go
+++ b/proxy/router/router_test.go
@@ -368,7 +368,9 @@ func TestWhereInPartitionByTableIndex(t *testing.T) {
 
 	// ensure no impact for not in
 	sql = "select * from test1 where id not in (0,1,2,3,4,5,6,7)"
-	checkPlan(t, sql, []int{8, 9, 10, 11}, []int{2})
+	checkPlan(t, sql,
+		[]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		[]int{0, 1, 2})
 
 }
 

--- a/proxy/router/router_test.go
+++ b/proxy/router/router_test.go
@@ -353,23 +353,25 @@ func checkPlan(t *testing.T, sql string, tableIndexs []int, nodeIndexs []int) {
 }
 func TestWhereInPartitionByTableIndex(t *testing.T) {
 	var sql string
+	t1 := makeList(0, 12)
+
 	//2016-08-02 13:37:26
 	sql = "select * from test1 where id in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22) "
 	checkPlan(t, sql,
-		[]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		t1,
 		[]int{0, 1, 2},
 	)
 	// ensure no impact for or operator in where
 	sql = "select * from test1 where id in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21) or name='test'"
 	checkPlan(t, sql,
-		[]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		t1,
 		[]int{0, 1, 2},
 	)
 
 	// ensure no impact for not in
 	sql = "select * from test1 where id not in (0,1,2,3,4,5,6,7)"
 	checkPlan(t, sql,
-		[]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		t1,
 		[]int{0, 1, 2})
 
 }
@@ -471,7 +473,7 @@ func TestSelectPlan(t *testing.T) {
 	checkPlan(t, sql, t1, []int{0, 1, 2})
 
 	sql = "select * from test1 where id not in (5, 6)"
-	checkPlan(t, sql, []int{0, 1, 2, 3, 4, 7, 8, 9, 10, 11}, []int{0, 1, 2})
+	checkPlan(t, sql, t1, []int{0, 1, 2})
 
 	sql = "select * from test1 where id in (5, 6) or (id in (5, 6, 7,8) and id in (1,5,7))"
 	checkPlan(t, sql, []int{5, 6, 7}, []int{1})


### PR DESCRIPTION
id not in (1, 2, 3) doesn't means that id is not in the table where 1, 2, 3 exists.