### PR TITLE
Archer.li/feature/issue 365

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -75,6 +75,7 @@ type ShardConfig struct {
 	Type          string   `yaml:"type"`
 	TableRowLimit int      `yaml:"table_row_limit"`
 	DateRange     []string `yaml:"date_range"`
+	TableNamePostfixLength int `yaml:"table_name_postfix_length"`
 }
 
 func ParseConfigData(data []byte) (*Config, error) {
@@ -82,6 +83,9 @@ func ParseConfigData(data []byte) (*Config, error) {
 	if err := yaml.Unmarshal([]byte(data), &cfg); err != nil {
 		return nil, err
 	}
+
+	setDefaultTblNamePostfixLength(&cfg)
+
 	return &cfg, nil
 }
 
@@ -105,6 +109,17 @@ func WriteConfigFile(cfg *Config) error {
 	err = ioutil.WriteFile(configFileName, data, 0755)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// set the default tbl_name postfix to 4, tbl_name_xxxx
+func setDefaultTblNamePostfixLength(cfg *Config) error {
+	for i := 0; i < len(cfg.Schema.ShardRule); i++ {
+		if cfg.Schema.ShardRule[i].TableNamePostfixLength == 0 {
+			cfg.Schema.ShardRule[i].TableNamePostfixLength = 4
+		}
 	}
 
 	return nil

--- a/proxy/server/conn_preshard.go
+++ b/proxy/server/conn_preshard.go
@@ -25,6 +25,7 @@ import (
 	"github.com/flike/kingshard/mysql"
 	"github.com/flike/kingshard/proxy/router"
 	"github.com/flike/kingshard/sqlparser"
+	"strconv"
 )
 
 type ExecuteDB struct {
@@ -462,13 +463,16 @@ func (c *ClientConn) handleShowColumns(sql string, tokens []string,
 				}
 				showRouter := c.schema.rule
 				showRule := showRouter.GetRule(ruleDB, tableName)
+				// tbl name format: tbl_name_xxxx
+				tblPostfixLength := showRule.TableNamePostfixLength
+				tblPostfixLengthStr := strconv.Itoa(tblPostfixLength)
 				//this SHOW is sharding SQL
 				if showRule.Type != router.DefaultRuleType {
 					if 0 < len(showRule.SubTableIndexs) {
 						tableIndex := showRule.SubTableIndexs[0]
 						nodeIndex := showRule.TableToNode[tableIndex]
 						nodeName := showRule.Nodes[nodeIndex]
-						tokens[i+2] = fmt.Sprintf("%s_%04d", tableName, tableIndex)
+						tokens[i+2] = fmt.Sprintf("%s_%0" + tblPostfixLengthStr + "d", tableName, tableIndex)
 						executeDB.sql = strings.Join(tokens, " ")
 						executeDB.ExecNode = c.schema.nodes[nodeName]
 						return nil


### PR DESCRIPTION
### What
Let kingshard support following table name format:
```bash
table_name_xxxxxxxx
table_name_%0nd # n can be any int number
```

### Why
Now kingshard only supports following table name format:
```bash
table_name_%04d
table_name_0000
````
but in some case, we have following table name format:
```bash
table_name_%0nd
table_name_00000001
```
### How
when kingshard tries to rewrite the sql statements, default is using ```%04d```, here i use ```%0nd```, n is the value configured in ```ks.yaml```, here is a sample config:
```yaml
# schema defines sharding rules, the db is the sharding table database.
schema :
    nodes: [node1]
    default: node1
    shard:
    -
        db : db
        table: tbl
        key: userid
        nodes: [node1]
        type: hash
        locations: [1000]
        table_name_post_fix_length: 8 # if you dont set here, will use default 4, i.e tbl_name_0000

```