### PR TITLE
将DB的监控和管理分离

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -78,6 +78,7 @@ func Open(addr string, user string, password string, dbName string, maxConnNum i
 
 	for i := 0; i < db.InitConnNum; i++ {
 		conn, err := db.newConn()
+		// try open as many as possbile, but not required
 		if err == nil {
 			conn.pushTimestamp = time.Now().Unix()
 			db.cacheConns <- conn

--- a/backend/node.go
+++ b/backend/node.go
@@ -66,7 +66,7 @@ func (n *Node) GetMasterConn() (*BackendConn, error) {
 	if db == nil {
 		return nil, errors.ErrNoMasterConn
 	}
-	if atomic.LoadInt32(&(db.state)) == Down {
+	if atomic.LoadInt32(&(db.state)) != Up {
 		return nil, errors.ErrMasterDown
 	}
 
@@ -84,13 +84,17 @@ func (n *Node) GetSlaveConn() (*BackendConn, error) {
 	if db == nil {
 		return nil, errors.ErrNoSlaveDB
 	}
-	if atomic.LoadInt32(&(db.state)) == Down {
+	if atomic.LoadInt32(&(db.state)) != Up {
 		return nil, errors.ErrSlaveDown
 	}
 
 	return db.GetConn()
 }
 
+// checkMaster
+// 1. assume Master == nil, after admin DownMaster, so skip check
+// 2. in normal condition, Master should never be not nil, even if db is down, so UpMaster should not called by checkMaster
+//
 func (n *Node) checkMaster() {
 	db := n.Master
 	if db == nil {
@@ -101,14 +105,6 @@ func (n *Node) checkMaster() {
 	if err := db.Ping(); err != nil {
 		golog.Error("Node", "checkMaster", "Ping", 0, "db.Addr", db.Addr(), "error", err.Error())
 	} else {
-		if atomic.LoadInt32(&(db.state)) == Down {
-			golog.Info("Node", "checkMaster", "Master up", 0, "db.Addr", db.Addr())
-			err := n.UpMaster(db.addr)
-			if err != nil {
-				golog.Error("Node", "checkMaster", "UpMaster", 0, "db.Addr", db.Addr(), "error", err.Error())
-				return
-			}
-		}
 		db.SetLastPing()
 		if atomic.LoadInt32(&(db.state)) != ManualDown {
 			atomic.StoreInt32(&(db.state), Up)
@@ -252,6 +248,7 @@ func (n *Node) UpDB(addr string) (*DB, error) {
 	return db, nil
 }
 
+// used for admin only
 func (n *Node) UpMaster(addr string) error {
 	db, err := n.UpDB(addr)
 	if err != nil {
@@ -262,6 +259,7 @@ func (n *Node) UpMaster(addr string) error {
 	return err
 }
 
+// used for admin only
 func (n *Node) UpSlave(addr string) error {
 	db, err := n.UpDB(addr)
 	if err != nil {
@@ -282,6 +280,7 @@ func (n *Node) UpSlave(addr string) error {
 	return err
 }
 
+// used for admin only
 func (n *Node) DownMaster(addr string, state int32) error {
 	db := n.Master
 	if db == nil || db.addr != addr {
@@ -293,6 +292,7 @@ func (n *Node) DownMaster(addr string, state int32) error {
 	return nil
 }
 
+// used for admin only
 func (n *Node) DownSlave(addr string, state int32) error {
 	n.RLock()
 	if n.Slave == nil {

--- a/backend/node.go
+++ b/backend/node.go
@@ -66,6 +66,8 @@ func (n *Node) GetMasterConn() (*BackendConn, error) {
 	if db == nil {
 		return nil, errors.ErrNoMasterConn
 	}
+
+	// ManualDown, Unknown are also not acceptable.  
 	if atomic.LoadInt32(&(db.state)) != Up {
 		return nil, errors.ErrMasterDown
 	}


### PR DESCRIPTION
1. DB能自动处理Connections的连接错误，因此如果不是系统性的错误，例如: 用户名错误等等，创建DB原则上不应该返回error。因此checkConn可以延后创建，或者创建失败了就直接跳过； InitConnNum也尽可能满足，如果不能满足也跳过

2. UpMaster & DownMaster 只负责处理Admin相关的逻辑，由外部行为驱动；
    checkMaster 属于内部行为，如果Node处于Down状态，那么checkMaster不工作；如果Node处于UpMaster状态，则checkMaster正常工作；checkMaster本身不改变UpMaster/DownMaster的逻辑。
    DB的状态一方面是看是否为nil, 另一方面看是否处于UP状态
   
    