### PR TITLE
#382, check date range when parsing conf

### DIFF
--- a/proxy/router/router.go
+++ b/proxy/router/router.go
@@ -192,6 +192,10 @@ func parseRule(cfg *config.ShardConfig) (*Rule, error) {
 			if err != nil {
 				return nil, err
 			}
+			currIndexLen := len(r.SubTableIndexs)
+			if currIndexLen > 0 && r.SubTableIndexs[currIndexLen-1] >= dayNumbers[0] {
+				return nil, errors.ErrDateIllegal
+			}
 			for _, v := range dayNumbers {
 				r.SubTableIndexs = append(r.SubTableIndexs, v)
 				r.TableToNode[v] = i
@@ -206,6 +210,10 @@ func parseRule(cfg *config.ShardConfig) (*Rule, error) {
 			if err != nil {
 				return nil, err
 			}
+			currIndexLen := len(r.SubTableIndexs)
+			if currIndexLen > 0 && r.SubTableIndexs[currIndexLen-1] >= monthNumbers[0] {
+				return nil, errors.ErrDateIllegal
+			}
 			for _, v := range monthNumbers {
 				r.SubTableIndexs = append(r.SubTableIndexs, v)
 				r.TableToNode[v] = i
@@ -219,6 +227,10 @@ func parseRule(cfg *config.ShardConfig) (*Rule, error) {
 			yearNumbers, err := ParseYearRange(cfg.DateRange[i])
 			if err != nil {
 				return nil, err
+			}
+			currIndexLen := len(r.SubTableIndexs)
+			if currIndexLen > 0 && r.SubTableIndexs[currIndexLen-1] >= yearNumbers[0] {
+				return nil, errors.ErrDateIllegal
 			}
 			for _, v := range yearNumbers {
 				r.TableToNode[v] = i


### PR DESCRIPTION
the data range must be strictly ordered.
e.g.
[201705-201706, 201707-201710] ok
[201705, 201706-201710] ok
[201705-201706, 201706-201710] error
[201705-201706, 201701-201702] error