### PR TITLE
make it record all sql when slowlogTime = 0

### DIFF
--- a/proxy/server/conn_query.go
+++ b/proxy/server/conn_query.go
@@ -210,7 +210,7 @@ func (c *ClientConn) executeInNode(conn *backend.BackendConn, sql string, args [
 	}
 	execTime := float64(time.Now().UnixNano()-startTime) / float64(time.Millisecond)
 	if strings.ToLower(c.proxy.logSql[c.proxy.logSqlIndex]) != golog.LogSqlOff &&
-		execTime > float64(c.proxy.slowLogTime[c.proxy.slowLogTimeIndex]) {
+		execTime >= float64(c.proxy.slowLogTime[c.proxy.slowLogTimeIndex]) {
 		c.proxy.counter.IncrSlowLogTotal()
 		golog.OutputSql(state, "%.1fms - %s->%s:%s",
 			execTime,
@@ -265,7 +265,7 @@ func (c *ClientConn) executeInMultiNodes(conns map[string]*backend.BackendConn, 
 			}
 			execTime := float64(time.Now().UnixNano()-startTime) / float64(time.Millisecond)
 			if c.proxy.logSql[c.proxy.logSqlIndex] != golog.LogSqlOff &&
-				execTime > float64(c.proxy.slowLogTime[c.proxy.slowLogTimeIndex]) {
+				execTime >= float64(c.proxy.slowLogTime[c.proxy.slowLogTimeIndex]) {
 				c.proxy.counter.IncrSlowLogTotal()
 				golog.OutputSql(state, "%.1fms - %s->%s:%s",
 					execTime,

--- a/proxy/server/conn_set.go
+++ b/proxy/server/conn_set.go
@@ -43,7 +43,7 @@ func (c *ClientConn) handleSet(stmt *sqlparser.Set, sql string) (err error) {
 		}
 		execTime := float64(time.Now().UnixNano()-startTime) / float64(time.Millisecond)
 		if c.proxy.logSql[c.proxy.logSqlIndex] != golog.LogSqlOff &&
-			execTime > float64(c.proxy.slowLogTime[c.proxy.slowLogTimeIndex]) {
+			execTime >= float64(c.proxy.slowLogTime[c.proxy.slowLogTimeIndex]) {
 			c.proxy.counter.IncrSlowLogTotal()
 			golog.OutputSql(state, "%.1fms - %s->%s:%s",
 				execTime,


### PR DESCRIPTION
两个问题：

1. slowlog丢日志严重
2. 当slowlogTime=0的时候，修改特征为记录下所有sql，而不是某个sql。

#508 

1. fix slowlog show less log than expected
2. modify it to record all sql when slowlogTime=0.