### PR TITLE
 修复handleShowColumns反单引号bug

### DIFF
--- a/proxy/server/conn_preshard.go
+++ b/proxy/server/conn_preshard.go
@@ -454,7 +454,7 @@ func (c *ClientConn) handleShowColumns(sql string, tokens []string,
 			i+2 < tokensLen {
 			if strings.ToLower(tokens[i+1]) == mysql.TK_STR_FROM {
 				// tableName := strings.Trim(tokens[i+2], "`")
-				DBName, tableName := sqlparser.GetDBTable(tokens[i+1])
+				DBName, tableName := sqlparser.GetDBTable(tokens[i+2])
 				if DBName != "" {
 					ruleDB = DBName
 				} else {

--- a/proxy/server/conn_preshard.go
+++ b/proxy/server/conn_preshard.go
@@ -453,7 +453,15 @@ func (c *ClientConn) handleShowColumns(sql string, tokens []string,
 			strings.ToLower(tokens[i]) == mysql.TK_STR_COLUMNS) &&
 			i+2 < tokensLen {
 			if strings.ToLower(tokens[i+1]) == mysql.TK_STR_FROM {
-				tableName := strings.Trim(tokens[i+2], "`")
+				// tableName := strings.Trim(tokens[i+2], "`")
+				// Fixd bug , show full columns from `db.table`
+				DBName, tableName := sqlparser.GetDBTable(tokens[i+1])
+				if DBName != "" {
+					ruleDB = DBName
+				} else {
+					ruleDB = c.db
+				}
+
 				//get the ruleDB
 				if i+4 < tokensLen && strings.ToLower(tokens[i+1]) == mysql.TK_STR_FROM {
 					ruleDB = strings.Trim(tokens[i+4], "`")

--- a/proxy/server/conn_preshard.go
+++ b/proxy/server/conn_preshard.go
@@ -454,7 +454,6 @@ func (c *ClientConn) handleShowColumns(sql string, tokens []string,
 			i+2 < tokensLen {
 			if strings.ToLower(tokens[i+1]) == mysql.TK_STR_FROM {
 				// tableName := strings.Trim(tokens[i+2], "`")
-				// Fixd bug , show full columns from `db.table`
 				DBName, tableName := sqlparser.GetDBTable(tokens[i+1])
 				if DBName != "" {
 					ruleDB = DBName


### PR DESCRIPTION
执行如下sql:
```bash
 SHOW FULL COLUMNS FROM `dbname`.`tablename`;
```

报错信息:
 ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '`.`tablename_0000' at line 1

问题:
反单引号解析bug, 例如 \`dbname\`.\`tablename\`会被解析为dbname\`.\`tablename;
