### PR TITLE
add free_os_memory选项

### DIFF
--- a/cmd/kingshard/main.go
+++ b/cmd/kingshard/main.go
@@ -21,8 +21,10 @@ import (
 	"os/signal"
 	"path"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/flike/kingshard/config"
 	"github.com/flike/kingshard/core/golog"
@@ -73,6 +75,24 @@ func main() {
 	if err != nil {
 		fmt.Printf("parse config file error:%v\n", err.Error())
 		return
+	}
+
+	if len(cfg.FreeOsMemory) > 0 {
+		go func() {
+			ts, err := time.ParseDuration(cfg.FreeOsMemory)
+			if err != nil {
+				fmt.Printf("paser free_os_memory fail:%s\n", err)
+				return
+			}
+
+			tk := time.NewTicker(ts)
+			for {
+				select {
+				case <-tk.C:
+					debug.FreeOSMemory()
+				}
+			}
+		}()
 	}
 
 	//when the log file size greater than 1GB, kingshard will generate a new file

--- a/config/config.go
+++ b/config/config.go
@@ -25,9 +25,10 @@ var configFileName string
 
 //整个config文件对应的结构
 type Config struct {
-	Addr     		string       	`yaml:"addr"`
-	PrometheusAddr 	string		 	`yaml:"prometheus_addr"`
-	UserList 		[]UserConfig 	`yaml:"user_list"`
+	FreeOsMemory   string       `yaml:"free_os_memory"`
+	Addr           string       `yaml:"addr"`
+	PrometheusAddr string       `yaml:"prometheus_addr"`
+	UserList       []UserConfig `yaml:"user_list"`
 
 	WebAddr     string `yaml:"web_addr"`
 	WebUser     string `yaml:"web_user"`


### PR DESCRIPTION
现象: kingshard 中间件拉数据发生out of memory
解决方法: 通过调用FreeOSMemory函数降低oom的风险
配置改变:

free_os_memory: 10s #具体的值可以配置,这里举例10s