### PR TITLE
fix: 修复表字段有大小写情况下，返回结果被转成小写造成使用方不便的问题

### DIFF
--- a/sqlparser/sql.go
+++ b/sqlparser/sql.go
@@ -2147,7 +2147,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line ./sqlparser/sql.y:1138
 		{
-			yyVAL.bytes = bytes.ToLower(yyDollar[1].bytes)
+			yyVAL.bytes = yyDollar[1].bytes
 		}
 	case 216:
 		yyDollar = yyS[yypt-0 : yypt+1]


### PR DESCRIPTION
场景: 
   比如表有个字段userId, 通过KS获取，结果会返回userid。 线上部署使用的是KS， 而开发过程中，使用的是MySQL，这就造成了一个严重的问题， 开发和测试发现不了问题，一上线就炸了。

现象:
   select * from xxx  的时候， 返回的字段是原始字段, 比如上面的 userId

   select userId from xx 的时候， 返回的字段就被转小写的，比如上面的会返回 userid
   
![image](https://user-images.githubusercontent.com/1431025/71607895-33b99a80-2bb8-11ea-9919-217469de990c.png)
![image](https://user-images.githubusercontent.com/1431025/71607914-47650100-2bb8-11ea-8ead-da82b78619ef.png)

