### PR TITLE
优化kingshard性能，解决连接池的链接对象逃逸问题，解决普罗米修斯对连接池使用的统计错误问题

### DIFF
--- a/backend/backend_conn.go
+++ b/backend/backend_conn.go
@@ -50,7 +50,6 @@ type Conn struct {
 	salt      []byte
 
 	pushTimestamp int64
-	checkChannel  chan int64
 	pkgErr        error
 }
 

--- a/backend/db.go
+++ b/backend/db.go
@@ -106,19 +106,6 @@ func Open(addr string, user string, password string, dbName string, maxConnNum i
 	return db, nil
 }
 
-func (db *DB) newCheckConn(conn *Conn) {
-	go func() {
-		select {
-		case <-conn.checkChannel:
-		case <-time.After(time.Second * 60 * 5):
-			conn := new(Conn)
-			db.idleConns <- conn
-			atomic.AddInt64(&db.pushConnCount, 1)
-			return
-		}
-	}()
-}
-
 func (db *DB) Addr() string {
 	return db.addr
 }
@@ -215,42 +202,59 @@ func (db *DB) newConn() (*Conn, error) {
 	}
 
 	co.pushTimestamp = time.Now().Unix()
-	co.checkChannel = make(chan int64)
 
 	return co, nil
 }
 
+func (db *DB) addIdleConn() {
+	conn := new(Conn)
+	select {
+	case db.idleConns <- conn:
+	default:
+		break
+	}
+}
+
 func (db *DB) closeConn(co *Conn) error {
+	atomic.AddInt64(&db.pushConnCount, 1)
+
 	if co != nil {
 		co.Close()
 		conns := db.getIdleConns()
 		if conns != nil {
 			select {
 			case conns <- co:
-				atomic.AddInt64(&db.pushConnCount, 1)
 				return nil
 			default:
 				return nil
 			}
 		}
+	} else {
+		db.addIdleConn()
+	}
+	return nil
+}
+
+func (db *DB) closeConnNotAdd(co *Conn) error {
+	if co != nil {
+		co.Close()
+		conns := db.getIdleConns()
+		if conns != nil {
+			select {
+			case conns <- co:
+				return nil
+			default:
+				return nil
+			}
+		}
+	} else {
+		db.addIdleConn()
 	}
 	return nil
 }
 
 func (db *DB) tryReuse(co *Conn) error {
 	var err error
-
-	//err = co.Ping()
-	//if err != nil {
-	//	db.closeConn(co)
-	//	co, err = db.newConn()
-	//
-	//	if err != nil {
-	//		db.Close()
-	//		return err
-	//	}
-	//}
-
 	//reuse Connection
 	if co.IsInTransaction() {
 		//we can not reuse a connection in transaction status
@@ -302,9 +306,6 @@ func (db *DB) PopConn() (*Conn, error) {
 		return nil, err
 	}
 
-	atomic.AddInt64(&db.popConnCount, 1)
-	// add check conn
-	db.newCheckConn(co)
 	return co, nil
 }
 
@@ -313,6 +314,7 @@ func (db *DB) GetConnFromCache(cacheConns chan *Conn) *Conn {
 	var err error
 	for 0 < len(cacheConns) {
 		co = <-cacheConns
+		atomic.AddInt64(&db.popConnCount, 1)
 		if co != nil && PingPeroid < time.Now().Unix()-co.pushTimestamp {
 			err = co.Ping()
 			if err != nil {
@@ -332,20 +334,20 @@ func (db *DB) GetConnFromIdle(cacheConns, idleConns chan *Conn) (*Conn, error) {
 	var err error
 	select {
 	case co = <-idleConns:
+		atomic.AddInt64(&db.popConnCount, 1)
 		co, err := db.newConn()
 		if err != nil {
 			db.closeConn(co)
 			return nil, err
 		}
-
 		err = co.Ping()
 		if err != nil {
 			db.closeConn(co)
 			return nil, errors.ErrBadConn
 		}
-
 		return co, nil
 	case co = <-cacheConns:
+		atomic.AddInt64(&db.popConnCount, 1)
 		if co == nil {
 			return nil, errors.ErrConnIsNil
 		}
@@ -361,7 +363,9 @@ func (db *DB) GetConnFromIdle(cacheConns, idleConns chan *Conn) (*Conn, error) {
 }
 
 func (db *DB) PushConn(co *Conn, err error) {
+	atomic.AddInt64(&db.pushConnCount, 1)
 	if co == nil {
+		db.addIdleConn()
 		return
 	}
 	conns := db.getCacheConns()
@@ -370,17 +374,15 @@ func (db *DB) PushConn(co *Conn, err error) {
 		return
 	}
 	if err != nil {
-		db.closeConn(co)
+		db.closeConnNotAdd(co)
 		return
 	}
 	co.pushTimestamp = time.Now().Unix()
 	select {
 	case conns <- co:
-		co.checkChannel <- co.pushTimestamp
-		atomic.AddInt64(&db.pushConnCount, 1)
 		return
 	default:
-		db.closeConn(co)
+		db.closeConnNotAdd(co)
 		return
 	}
 }

--- a/proxy/server/conn.go
+++ b/proxy/server/conn.go
@@ -265,6 +265,14 @@ func (c *ClientConn) readHandshakeResponse() error {
 	return nil
 }
 
+func (c *ClientConn) clean() {
+	if c.txConns != nil && len(c.txConns) > 0 {
+		for _, co := range c.txConns {
+			co.Close()
+		}
+	}
+}
+
 func (c *ClientConn) Run() {
 	defer func() {
 		r := recover()
@@ -280,7 +288,7 @@ func (c *ClientConn) Run() {
 
 		c.Close()
 	}()
-
+	defer c.clean()
 	for {
 		data, err := c.readPacket()
 

--- a/proxy/server/conn_query.go
+++ b/proxy/server/conn_query.go
@@ -307,12 +307,10 @@ func (c *ClientConn) closeConn(conn *backend.BackendConn, rollback bool) {
 	if c.isInTransaction() {
 		return
 	}
-
+	defer conn.Close()
 	if rollback {
 		conn.Rollback()
 	}
-
-	conn.Close()
 }
 
 func (c *ClientConn) closeShardConns(conns map[string]*backend.BackendConn, rollback bool) {


### PR DESCRIPTION
backend/db.go中的PopConn在每次执行转发sql之前均会被执行，在tryReuse中对每个链接均进行了ping操作，在sysbench基准压测时，通过火焰图分析，此处消耗很多的CPU时间和频繁的系统调用开销。对此进行逻辑优化，即用原有的5s中一次的cache链接的ping检查，新建的链接在建立完成后直接进行ping操作