### PR TITLE
fix parse statement execute proto bug

### DIFF
--- a/proxy/server/conn_stmt.go
+++ b/proxy/server/conn_stmt.go
@@ -45,6 +45,7 @@ type Stmt struct {
 	columns int
 
 	args []interface{}
+	paramTypes []byte
 
 	s sqlparser.Statement
 
@@ -204,7 +205,6 @@ func (c *ClientConn) handleStmtExecute(data []byte) error {
 	pos += 4
 
 	var nullBitmaps []byte
-	var paramTypes []byte
 	var paramValues []byte
 
 	paramNum := s.params
@@ -224,13 +224,13 @@ func (c *ClientConn) handleStmtExecute(data []byte) error {
 				return mysql.ErrMalformPacket
 			}
 
-			paramTypes = data[pos : pos+(paramNum<<1)]
+			s.paramTypes = data[pos : pos+(paramNum<<1)]
 			pos += (paramNum << 1)
 
-			paramValues = data[pos:]
 		}
+		paramValues = data[pos:]
 
-		if err := c.bindStmtArgs(s, nullBitmaps, paramTypes, paramValues); err != nil {
+		if err := c.bindStmtArgs(s, nullBitmaps, s.paramTypes, paramValues); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
According to COM_STMT_EXECUTE protocol definition: https://dev.mysql.com/doc/internals/en/com-stmt-execute.html

`  
      if new-params-bound-flag == 1:
    n              type of each parameter, length: num-params * 2
    n              value of each parameter
`
new-params-bound-flag condition only valid for the first statement: `type of each parameter`, `value of each parameter` field should be parse every time.
If not parse this field, STMT can only be executed once.