### PR TITLE
fix trim with useless space

### DIFF
--- a/proxy/server/conn_stmt.go
+++ b/proxy/server/conn_stmt.go
@@ -62,7 +62,7 @@ func (c *ClientConn) handleStmtPrepare(sql string) error {
 
 	s := new(Stmt)
 
-	sql = strings.TrimRight(sql, ";")
+	sql = strings.TrimRight(strings.TrimRight(sql, " "), ";")
 
 	var err error
 	s.s, err = sqlparser.Parse(sql)


### PR DESCRIPTION
```sql
select 1;    # sql ends with space
```
This situation we should handle with the uselesss right-space first, or the sql will be parsed will with the `;`, which will cause an error but should not be.